### PR TITLE
Make adjustments necessary for use within Atom's new release publisher application

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "babel-plugin-transform-regenerator": "^6.1.4",
     "babel-polyfill": "^6.1.4",
     "babel-preset-es2015": "^6.1.4"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.14.0"
   }
 }

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -69,10 +69,12 @@ function getCommitDiffLocal({owner, repo, base, head, localClone}) {
   return commits
 }
 
-// This will only return 250 commits when using the API
 async function getCommitDiffRemote({owner, repo, base, head}) {
   authenticate()
 
+  // Fetch comparisons recursively until we don't find any commits
+  // This is because the GitHub API limits the number of commits returned in
+  // a single response.
   let commits = []
   let compareHead = head
   let compareResult

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -18,10 +18,15 @@ Promise.promisifyAll(github.repos);
 Promise.promisifyAll(github.issues);
 Promise.promisifyAll(github.pullRequests);
 
+let githubAccessToken
+function setGithubAccessToken (token) {
+  githubAccessToken = token
+}
+
 function authenticate() {
   github.authenticate({
     type: "oauth",
-    token: process.env['GITHUB_ACCESS_TOKEN']
+    token: githubAccessToken || process.env['GITHUB_ACCESS_TOKEN']
   });
 }
 
@@ -400,5 +405,6 @@ async function getChangelog(options) {
 module.exports = {
   getChangelog: getChangelog,
   pullRequestsToString: pullRequestsToString,
-  defaultChangelogFormatter: defaultChangelogFormatter
+  defaultChangelogFormatter: defaultChangelogFormatter,
+  setGithubAccessToken: setGithubAccessToken
 }


### PR DESCRIPTION
- Improve commit fetching from the GitHub API to work around 250 commit limitation.
- Fetch everything in parallel to improve latency. Add context to log messages to make things somewhat less confusing now that they're all mixed up.
- Allow GitHub access token to be assigned programmatically. We use the token of the authenticated user so environment variables don't work.

/cc @as-cii
