### PR TITLE
Allow enterprise github usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/benogle/pr-changelog#readme",
   "dependencies": {
     "bluebird": "^3.0.6",
+    "babel-polyfill": "^6.1.4",
     "expand-home-dir": "0.0.3",
     "github": "^3.0.0",
     "moment": "^2.10.6",
@@ -38,7 +39,6 @@
     "babel-cli": "^6.14.0",
     "babel-plugin-syntax-async-functions": "^6.1.4",
     "babel-plugin-transform-regenerator": "^6.1.4",
-    "babel-polyfill": "^6.1.4",
     "babel-preset-es2015": "^6.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,13 @@
   "dependencies": {
     "bluebird": "^3.0.6",
     "expand-home-dir": "0.0.3",
-    "github": "^0.1.16",
+    "github": "^3.0.0",
     "moment": "^2.10.6",
     "parse-link-header": "^0.4.1",
-    "yargs": "^3.31.0",
+    "yargs": "^3.31.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.14.0",
     "babel-plugin-syntax-async-functions": "^6.1.4",
     "babel-plugin-transform-regenerator": "^6.1.4",
     "babel-polyfill": "^6.1.4",

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,9 @@ let argv = require('yargs')
   .boolean('v')
   .alias('v', 'verbose')
   .describe('v', 'Verbose')
+  .alias('H', 'host')
+  .describe('H', 'If using private Enterprise Github, host. Might require a path-prefix')
+  .describe('path-prefix', 'API path prefix used if reaching a private Enterprise Github, default to /api/v3')
   .help('h')
   .alias('h', 'help')
   .demand(1)
@@ -38,7 +41,8 @@ Changelog.getChangelog({
   toTag: toTag,
   localClone: localClone,
   dependencyKey: dependencyKey,
-  changelogFormatter: Changelog.defaultChangelogFormatter
+  changelogFormatter: Changelog.defaultChangelogFormatter,
+  gitOpts: {host: argv.host, pathPrefix: argv['path-prefix']}
 }).then(function(output) {
   console.log(output);
 }).catch(function(err) {


### PR DESCRIPTION
Allows to configuer host and API path prefix to allow usage of Enterprise
on premise Github repos.

Also update to latest github API wrapper, required to access Enterprise Github.
