### PR TITLE
Specify access token via Authorization header

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -25,7 +25,7 @@ function setGithubAccessToken (token) {
 
 function authenticate() {
   github.authenticate({
-    type: "oauth",
+    type: "token",
     token: githubAccessToken || process.env['GITHUB_ACCESS_TOKEN']
   });
 }


### PR DESCRIPTION
Fixes
`[Error: {"message":"Must specify access token via Authorization header. https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param","documentation_url":"[](https://docs.github.com/v3/#oauth2-token-sent-in-a-header)"}] {
  code: 400
}`